### PR TITLE
When generating #define for integers, bracket the result

### DIFF
--- a/src/configurator.ml
+++ b/src/configurator.ml
@@ -349,7 +349,7 @@ module C_define = struct
         match (value : Value.t) with
         | Switch false -> sprintf "#undef  %s" name
         | Switch true  -> sprintf "#define %s" name
-        | Int    n     -> sprintf "#define %s %d" name n
+        | Int    n     -> sprintf "#define %s (%d)" name n
         | String s     -> sprintf "#define %s %S" name s)
     in
     let lines =


### PR DESCRIPTION
This makes it more robust in the face of negative integers, which
in turn fixes the build of Core.v0.9.0 on FreeBSD, where a few
values default to (-1) and fail to build with a cpp syntax error.