### PR TITLE
No ppx

### DIFF
--- a/configurator.opam
+++ b/configurator.opam
@@ -10,11 +10,8 @@ build: [
 ]
 depends: [
   "base"
-  "ppx_base"
-  "ppx_driver"
   "stdio"
   "jbuilder"                {build & >= "1.0+beta12"}
-  "ocaml-migrate-parsetree" {>= "0.4"}
 ]
 available: [ ocaml-version >= "4.04.1" ]
 descr: "

--- a/src/configurator.mli
+++ b/src/configurator.mli
@@ -28,7 +28,11 @@ module C_define : sig
       | Switch (** defined/undefined *)
       | Int
       | String
-    [@@deriving compare, sexp]
+
+    val sexp_of_t : t -> Sexp.t
+    val t_of_sexp : Sexp.t -> t
+
+    val compare : t -> t -> int
   end
 
   module Value : sig
@@ -36,7 +40,11 @@ module C_define : sig
       | Switch of bool
       | Int    of int
       | String of string
-    [@@deriving compare, sexp]
+
+    val sexp_of_t : t -> Sexp.t
+    val t_of_sexp : Sexp.t -> t
+
+    val compare : t -> t -> int
   end
 
   (** Import some #define from the given header files. For instance:

--- a/src/jbuild
+++ b/src/jbuild
@@ -2,7 +2,6 @@
  ((name        configurator)
   (public_name configurator)
   (flags (:standard -safe-string))
-  (libraries (base stdio unix))
-  (preprocess (pps (ppx_base ppx_driver.runner)))))
+  (libraries (base stdio unix))))
 
 (jbuild_version 1)


### PR DESCRIPTION
Configurator is a key dependency of many packages so it would be really nice to reduce its dependency profile. Ppx brings in quite a few dependencies to save us from manually writing 6 functions. I suggest we make the trade off the other way and suffer a little boilerplate.